### PR TITLE
Handling child_process.spawn() parameter "windowsVerbatimArguments"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-    "name":"stateful-process-command-proxy",
-    "version":"1.0.1",
-    "description":"Module for executing commands in shells (bash or powershell etc) against a pool of stateful child processes such as bash or powershell via stdout and stderr streams",
-    "main":"statefulProcessCommandProxy.js",
-    "directories":{
-        "test":"test"
+    "name": "stateful-process-command-proxy",
+    "version": "1.0.1",
+    "description": "Module for executing commands in shells (bash or powershell etc) against a pool of stateful child processes such as bash or powershell via stdout and stderr streams",
+    "main": "statefulProcessCommandProxy.js",
+    "directories": {
+        "test": "test"
     },
-    "scripts":{
-        "test":"mocha test/all.js"
+    "scripts": {
+        "test": "mocha test/all.js"
     },
-    "keywords":[
+    "keywords": [
         "command",
         "process",
         "dos",
@@ -22,28 +22,29 @@
         "execute",
         "exec"
     ],
-    "dependencies":{
-        "buffer-builder":"latest",
-        "fifo":"latest",
-        "promise":"latest",
-        "generic-pool":"2.4.4"
+    "dependencies": {
+        "buffer-builder": "latest",
+        "fifo": "latest",
+        "generic-pool": "2.4.4",
+        "mobx": "^5.15.2",
+        "promise": "latest"
     },
-    "devDependencies":{
-        "mocha":"latest"
+    "devDependencies": {
+        "mocha": "latest"
     },
-    "contributors":[
+    "contributors": [
         {
-            "name":"bitsofinfo",
-            "url":"http://bitsofinfo.wordpress.com"
+            "name": "bitsofinfo",
+            "url": "http://bitsofinfo.wordpress.com"
         }
     ],
-    "license":"ISC",
-    "repository":{
-        "type":"git",
-        "url":"https://github.com/bitsofinfo/stateful-process-command-proxy.git"
+    "license": "ISC",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/bitsofinfo/stateful-process-command-proxy.git"
     },
-    "bugs":{
-        "url":"https://github.com/bitsofinfo/stateful-process-command-proxy/issues"
+    "bugs": {
+        "url": "https://github.com/bitsofinfo/stateful-process-command-proxy/issues"
     },
-    "homepage":"https://github.com/bitsofinfo/stateful-process-command-proxy"
+    "homepage": "https://github.com/bitsofinfo/stateful-process-command-proxy"
 }

--- a/processProxy.js
+++ b/processProxy.js
@@ -114,7 +114,9 @@ fifo.prototype.toArray = function () {
 *             ]
 *        }
 *
-*
+* @param windowsVerbatimArguments : optional boolean which, on win32 only, will prevent or allow parameter quoting (as defined in
+*                                   child_process.spawn() method)
+*                                   By default, this setting has value true (no escaping)
 *
 */
 function ProcessProxy(processToSpawn, args,
@@ -122,7 +124,8 @@ function ProcessProxy(processToSpawn, args,
                       cwd, envMap, uid, gid, logFunction,
                       processCmdBlacklistRegex,
                       processCmdWhitelistRegex,
-                      autoInvalidationConfig) {
+                      autoInvalidationConfig,
+                      windowsVerbatimArguments) {
 
     this._createdAt = new Date();
     this._processPid = null;
@@ -187,6 +190,7 @@ function ProcessProxy(processToSpawn, args,
     if (gid) {
         this._processOptions['gid'] = gid;
     }
+    this._processOptions['windowsVerbatimArguments'] = !(windowsVerbatimArguments === false);
 
     this._commandStack = new fifo();
 

--- a/processProxy.js
+++ b/processProxy.js
@@ -4,6 +4,7 @@ var fifo = require('fifo');
 var Command = require('./command');
 var spawn = require('child_process').spawn;
 var Promise = require('promise');
+const { observable, action } = require('mobx');
 
 var MARKER_DONE = '__done__';
 
@@ -134,7 +135,7 @@ function ProcessProxy(processToSpawn, args,
     this._logFunction = logFunction;
 
 
-    this._commandHistory = [];
+    this._commandHistory = observable([]);
     if(typeof(retainMaxCmdHistory)==='undefined') {
         this._retainMaxCmdHistory = 0;
 
@@ -369,7 +370,8 @@ ProcessProxy.prototype.isValid = function() {
 *   internal method that analyzes a just finish()ed command and
 *   evaluates all process invalidation regexes against it
 **/
-ProcessProxy.prototype._handleCommandFinished = function(command) {
+
+ProcessProxy.prototype._handleCommandFinished = action(function(command) {
     if (command && command.isCompleted()) {
 
         // store command history...
@@ -427,7 +429,7 @@ ProcessProxy.prototype._handleCommandFinished = function(command) {
             }
         }
     }
-}
+})
 
 /**
 * _commandIsBlacklisted(command)
@@ -617,11 +619,14 @@ ProcessProxy.prototype.initialize = function(initCommands) {
 
             // register stdout stream handler
             self._process.stdout.on('data', function(data) {
+                console.log(`[${self._process.pid}] [out] ${data}`);
                 self.onData('stdout', data);
             });
 
             // register stderr stream handler
             self._process.stderr.on('data', function(data) {
+                console.log(`[${self._process.pid}] [err] ${data}`);
+                
                 self.onData('stderr', data);
             });
 

--- a/statefulProcessCommandProxy.js
+++ b/statefulProcessCommandProxy.js
@@ -3,7 +3,7 @@ module.exports = StatefulProcessCommandProxy;
 var poolModule = require('generic-pool');
 var ProcessProxy = require('./processProxy');
 var Promise = require('promise');
-const { observable } = require('mobx');
+const { observable, action } = require('mobx');
 
 /**
 * StatefulProcessCommandProxy is the gateway for executing commands
@@ -156,12 +156,12 @@ function StatefulProcessCommandProxy(config) {
                 // initialize
                 processProxy.initialize(config.initCommands)
 
-                .then(function(cmdResults) {
+                .then(action('initStatefulProcessCommandProxy',function(cmdResults) {
                     self._log('info',"new process ready, initialization commands completed. ("+processProxy.getPid()+')');
                     self._pid2processMap[processProxy.getPid()] = processProxy; // register in our process map
                     callback(null, processProxy);
 
-                }).catch(function(exception) {
+                })).catch(function(exception) {
                     self._log('error',"new process initialize threw error: " + exception + ' ' + exception.stack);
                 });
 
@@ -181,7 +181,7 @@ function StatefulProcessCommandProxy(config) {
         },
 
 
-        destroy: function(processProxy) {
+        destroy: action('destroyPid2ProcessMap', function(processProxy) {
 
             try {
                 processProxy.shutdown(config.preDestroyCommands)
@@ -212,7 +212,7 @@ function StatefulProcessCommandProxy(config) {
                     config.preDestroyCommands + "] exception: " + e);
             }
 
-        },
+        }),
 
         // maximum number in the pool
         max: config.max,

--- a/statefulProcessCommandProxy.js
+++ b/statefulProcessCommandProxy.js
@@ -3,6 +3,7 @@ module.exports = StatefulProcessCommandProxy;
 var poolModule = require('generic-pool');
 var ProcessProxy = require('./processProxy');
 var Promise = require('promise');
+const { observable } = require('mobx');
 
 /**
 * StatefulProcessCommandProxy is the gateway for executing commands
@@ -124,7 +125,7 @@ function StatefulProcessCommandProxy(config) {
     this._logFunction = config.logFunction;
 
     // map of all process PIDs -> ProcessProxies
-    this._pid2processMap = new Object();
+    this._pid2processMap =  observable(new Object());
 
     var self = this;
 
@@ -156,7 +157,7 @@ function StatefulProcessCommandProxy(config) {
                 processProxy.initialize(config.initCommands)
 
                 .then(function(cmdResults) {
-                    self._log('info',"new process ready, initialization commands completed.");
+                    self._log('info',"new process ready, initialization commands completed. ("+processProxy.getPid()+')');
                     self._pid2processMap[processProxy.getPid()] = processProxy; // register in our process map
                     callback(null, processProxy);
 

--- a/statefulProcessCommandProxy.js
+++ b/statefulProcessCommandProxy.js
@@ -111,6 +111,9 @@ var Promise = require('promise');
               },...
             ]
        }
+       windowsVerbatimArguments : optional boolean which, on win32 only, will prevent or allow parameter quoting (as defined in
+                                  child_process.spawn() method)
+                                  By default, this setting has value true (no escaping)
 
 *
 **/
@@ -145,7 +148,8 @@ function StatefulProcessCommandProxy(config) {
                                                 config.logFunction,
                                                 config.processCmdBlacklistRegex,
                                                 config.processCmdWhitelistRegex,
-                                                config.autoInvalidationConfig);
+                                                config.autoInvalidationConfig,
+                                                config.windowsVerbatimArguments);
 
 
                 // initialize


### PR DESCRIPTION
Here is a basic implementation which solve the following issue :

https://github.com/bitsofinfo/stateful-process-command-proxy/issues/17

TLDR : Under Windows, child_process.spawn() method escape process arguments and add quotes to them. This can lead to improper parameter handling by the called process.

Example: If we pass the following `processCommand` and `processArgs` parameters to the `StatefulProcessCommandProxy`
```
const processCommand = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
const processArgs = ['-NoProfile -ExecutionPolicy bypass']
```

This pull request provide a new parameter to ProcessProxy to handle this.