### PR TITLE
Fix slice cropping data output

### DIFF
--- a/processProxy.js
+++ b/processProxy.js
@@ -549,7 +549,7 @@ ProcessProxy.prototype.onData = function(type, data) {
                 } else {
 
                     // extract all data up-to the DONE marker...
-                    var block = data.slice(startIdx, doneIdx - 1);
+                    var block = data.slice(startIdx, doneIdx);
 
                     // apply the data and finish the command
                     if (cmd) {


### PR DESCRIPTION
The call to slice is treated as if the end of slice is inclusive, where it is not. This means the last character is being cut off for the block variable. As this part of the code is only called under some circumstances, to an end user, most of the time this function works as expected, but sometimes the last character will be cropped.